### PR TITLE
Re-add data-qa tag to message about token security.

### DIFF
--- a/pages/manage-access.tsx
+++ b/pages/manage-access.tsx
@@ -195,7 +195,7 @@ export const GenerateTokenComponent: ChakraComponent<'div', GTCprops>
               />
               <CopyButton copyContent={generatedToken} position="absolute" top="8px" />
             </Box>
-            <AttentionBar description={'For security reasons, this key will not be displayed again. Please copy it now and keep it securely.'} />
+            <AttentionBar data-qa="message-token-security" description={'For security reasons, this key will not be displayed again. Please copy it now and keep it securely.'} />
 
             {codeExample && <>
               <Text color='smBlack.300'>


### PR DESCRIPTION
So E2E tests always find the right element regardless of text changes.