### PR TITLE
reset runtime auth on logout

### DIFF
--- a/utils/msal-utils.ts
+++ b/utils/msal-utils.ts
@@ -1,6 +1,7 @@
 import { EventType, PublicClientApplication } from '@azure/msal-browser';
 import { makeAutoObservable, makeObservable } from 'mobx';
 import { accountStore, tokenStore } from './account-store-context';
+import { runtimeAuthFlow } from './runtime-auth-flow';
 import { msalConfig } from './auth-config';
 
 export const msalInstance = new PublicClientApplication(msalConfig);
@@ -29,7 +30,7 @@ export function msalLogout(inactive: boolean = false) {
   const authority = `https://${process.env.AUTHORITY_DOMAIN}/${process.env.POLICY_DOMAIN}/${
     (account?.idTokenClaims as any)?.acr
   }`;
-
+  runtimeAuthFlow.reset()
   accountStore.clear();
   msalInstance.logoutRedirect({
     account: account,

--- a/utils/runtime-auth-flow.ts
+++ b/utils/runtime-auth-flow.ts
@@ -92,7 +92,7 @@ class RuntimeAuthFlow {
 
   reset(error: string = null) {
     this.store.resetStore(error);
-    sessionStorage.setItem('runtime_token', null);
+    sessionStorage.removeItem('runtime_token');
   }
 }
 


### PR DESCRIPTION
Purpose

When logging out, runtime auth doesn't reset. This isn't ideal, for security reasons, and also - edge case - if you log into two different users, you will remain logged into first users runtime auth