### PR TITLE
decrease trnascription viewer height to solve scroll problem

### DIFF
--- a/components/recent-jobs.tsx
+++ b/components/recent-jobs.tsx
@@ -151,7 +151,7 @@ export const RecentJobs = observer(() => {
         onClose={() => setTranscriptOpen(false)}
       >
         <ModalOverlay rounded="none" />
-        <ModalContent p={4} rounded="none" h="70vh">
+        <ModalContent p={4} rounded="none">
           <ModalHeader fontSize="2em" textAlign="center">
             Transcription of "{activeJob?.fileName}"
           </ModalHeader>
@@ -169,7 +169,7 @@ export const RecentJobs = observer(() => {
             right={-4}
           />
           <ModalBody>
-            <TranscriptionViewer {...activeJob} transcMaxHeight="38vh" />
+            <TranscriptionViewer {...activeJob} transcMaxHeight="25vh" />
           </ModalBody>
         </ModalContent>
       </Modal>

--- a/components/transcription-viewer.tsx
+++ b/components/transcription-viewer.tsx
@@ -17,7 +17,7 @@ export type TranscriptionViewerProps = {
   transcMaxHeight?: string;
 } & BoxProps;
 
-export const TranscriptionViewer = ({ transcriptionText, date, jobId, accuracy, language, transcMaxHeight = '1em', ...boxProps }: TranscriptionViewerProps) => (
+export const TranscriptionViewer = ({ transcriptionText, date, jobId, accuracy, language, transcMaxHeight = '10em', ...boxProps }: TranscriptionViewerProps) => (
   <VStack border='1px' borderColor='smBlack.200' width='100%' {...boxProps}>
     <HStack justifyContent='space-between' width='100%' px={6} py={3} bgColor='smNavy.200'
       borderBottom='1px'

--- a/components/transcription-viewer.tsx
+++ b/components/transcription-viewer.tsx
@@ -17,7 +17,7 @@ export type TranscriptionViewerProps = {
   transcMaxHeight?: string;
 } & BoxProps;
 
-export const TranscriptionViewer = ({ transcriptionText, date, jobId, accuracy, language, transcMaxHeight = '10em', ...boxProps }: TranscriptionViewerProps) => (
+export const TranscriptionViewer = ({ transcriptionText, date, jobId, accuracy, language, transcMaxHeight = '1em', ...boxProps }: TranscriptionViewerProps) => (
   <VStack border='1px' borderColor='smBlack.200' width='100%' {...boxProps}>
     <HStack justifyContent='space-between' width='100%' px={6} py={3} bgColor='smNavy.200'
       borderBottom='1px'


### PR DESCRIPTION
Decrease the height of the transcription viewer so medium sized screens won't have issues viewing transcription content with buttons