### PR TITLE
fix list update when job is done uploading and add error display

### DIFF
--- a/components/file-transcription/files-being-uploaded.tsx
+++ b/components/file-transcription/files-being-uploaded.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react-lite';
 import { useRef } from 'react';
 import { pluralize } from '../../utils/string-utils';
 import { fileTranscriptionFlow } from '../../utils/transcribe-store-flow';
+import { ErrorBanner } from '../common';
 
 
 interface FilesBeingUploadedProps {
@@ -11,6 +12,7 @@ interface FilesBeingUploadedProps {
 
 export default observer(function FilesBeingUploaded({ forceGetJobs }: FilesBeingUploadedProps) {
   const count = fileTranscriptionFlow.store.uploadedFiles.length;
+  const { uploadErrors } = fileTranscriptionFlow.store;
 
   useTrackUploadedJobs(count, forceGetJobs);
 
@@ -19,6 +21,7 @@ export default observer(function FilesBeingUploaded({ forceGetJobs }: FilesBeing
       <Box color='smNavy.400'>{pluralize(count, 'file is', 'files are')} being uploaded in the background.</Box>
       <Progress size='xs' isIndeterminate width='40%' colorScheme='smBlue' />
     </VStack>}
+    {uploadErrors.map(item => <ErrorBanner text={item}/>)}
   </>
 })
 

--- a/components/recent-jobs.tsx
+++ b/components/recent-jobs.tsx
@@ -63,6 +63,7 @@ export const RecentJobs = observer(() => {
     noMoreJobs,
     onDeleteJob,
     forceGetJobs,
+    errorGettingNewJob,
   } = useJobs(pageLimit, page);
 
   const onOpenTranscript = useCallback(
@@ -113,6 +114,7 @@ export const RecentJobs = observer(() => {
 
       <FilesBeingUploaded forceGetJobs={forceGetJobs} />
 
+      {errorGettingNewJob && <ErrorBanner text="We couldn't get your recently uploaded jobs." />}
       <VStack spacing={6} pt={6} width="100%">
         {isLoading && skeletons}
         {!errorOnInit &&

--- a/utils/transcribe-store-flow.ts
+++ b/utils/transcribe-store-flow.ts
@@ -115,8 +115,20 @@ export class FileTranscriptionStore {
     return this._errorDetail;
   }
 
+  _uploadErrors: string[] = [];
+  set uploadErrors(value: string[]) {
+    this._uploadErrors = value;
+  }
+  get uploadErrors(): string[] {
+    return this._uploadErrors;
+  }
+
   constructor() {
     makeAutoObservable(this);
+  }
+
+  addUploadError(error: string) {
+    this._uploadErrors.push(error)
   }
 
   resetStore() {
@@ -131,6 +143,7 @@ export class FileTranscriptionStore {
     this.transcriptionText = '';
     this.dateSubmitted = '';
     this.error = null;
+    this.uploadErrors = []
   }
 
   get fileName() {
@@ -225,8 +238,8 @@ class FileTranscribeFlow {
     const store = this.store;
     const owner = this;
     return function (resp: any) {
+      store.addUploadError("Error uploading " + file.name + ": " + resp.response.detail)
       owner.store.removeFileFromUploading(file);
-
       if (file !== store.file) return;
       if (store.stage !== 'pendingFile') return;
 
@@ -256,9 +269,7 @@ class FileTranscribeFlow {
     } else {
       this.store.error = FlowError.UndefinedError;
     }
-
     this.store.errorDetail = error.response?.detail || '';
-
     //add BeyondAllowedQuota, FileTooBig, FileWrongType
   }
 

--- a/utils/use-jobs-hook.ts
+++ b/utils/use-jobs-hook.ts
@@ -10,6 +10,7 @@ export const useJobs = (limit, page) => {
   const [isWaitingOnMore, setIsWaitingOnMore] = useState<boolean>(false);
   const [errorOnInit, setErrorOnInit] = useState<boolean>(false);
   const [errorGettingMore, setErrorGettingMore] = useState<boolean>(false);
+  const [errorGettingNewJob, setErrorGettingNewJob] = useState<boolean>(false);
   const [createdBefore, setCreatedBefore] = useState<string>(null);
   const [isPolling, setIsPolling] = useState<boolean>(false);
 
@@ -86,16 +87,16 @@ export const useJobs = (limit, page) => {
       idToken,
       jobs,
       setJobs,
-      createdBefore,
-      setCreatedBefore,
+      null,
+      () => {},
       limit,
       noMoreJobs,
       setNoMoreJobs,
       setIsPolling,
-      setIsLoading,
-      setErrorOnInit
+      () => {},
+      setErrorGettingNewJob
     );
-  }, [createdBefore, idToken, limit, noMoreJobs]);
+  }, [idToken, jobs]);
 
   return {
     jobs,
@@ -107,6 +108,7 @@ export const useJobs = (limit, page) => {
     noMoreJobs,
     onDeleteJob,
     forceGetJobs,
+    errorGettingNewJob,
   };
 };
 
@@ -121,7 +123,7 @@ const getJobs = (
   setNoMoreJobs: Dispatch<boolean>,
   setIsPolling: Dispatch<boolean>,
   loadingFunction: Dispatch<boolean>,
-  errorFunction: Dispatch<boolean>,
+  errorFunction: Dispatch<boolean>
 ) => {
   let isActive = true;
   if (idToken && !noMoreJobs) {
@@ -146,7 +148,7 @@ const getJobs = (
             const formatted: JobElementProps[] = formatJobs(respJson.jobs);
             const combinedArrays: JobElementProps[] = createSet(jobs, formatted, true);
             setCreatedBefore(respJson.jobs[respJson.jobs.length - 1].created_at);
-            setJobs(combinedArrays);
+            setJobs([...combinedArrays]);
             if (combinedArrays.some((item) => item.status === 'running')) {
               setIsPolling(true);
             } else {
@@ -268,7 +270,8 @@ const createSet = (
       first[index] = item;
     }
   }
-  return first;
+
+  return first.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 };
 
 export type JobElementProps = {


### PR DESCRIPTION
Purpose:
* Make sure jobs are updated when using forceGetJobs on finish upload
* Make sure jobs are ordered correctly
* Prevent janky jump in screen on update
* Add simple error display to jobs list on upload failure